### PR TITLE
Fish 6759 search cdi manager via jndi

### DIFF
--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -46,7 +46,7 @@
     <parent>
        <groupId>org.glassfish.soteria</groupId>
        <artifactId>parent</artifactId>
-       <version>1.1-b01.payara-p6-SNAPSHOT</version>
+       <version>1.1-b01.payara-p6</version>
     </parent>
 
     <artifactId>javax.security.enterprise</artifactId>

--- a/impl/src/main/java/org/glassfish/soteria/mechanisms/jaspic/HttpBridgeServerAuthModule.java
+++ b/impl/src/main/java/org/glassfish/soteria/mechanisms/jaspic/HttpBridgeServerAuthModule.java
@@ -44,9 +44,7 @@ package org.glassfish.soteria.mechanisms.jaspic;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.logging.Logger;
 
-import javax.enterprise.inject.spi.CDI;
 import javax.security.auth.Subject;
 import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.message.AuthException;
@@ -70,6 +68,7 @@ import org.glassfish.soteria.mechanisms.HttpMessageContextImpl;
 
 import static javax.security.enterprise.AuthenticationStatus.NOT_DONE;
 import static javax.security.enterprise.AuthenticationStatus.SEND_FAILURE;
+import org.glassfish.soteria.cdi.CdiUtils;
 import static org.glassfish.soteria.mechanisms.jaspic.Jaspic.fromAuthenticationStatus;
 import static org.glassfish.soteria.mechanisms.jaspic.Jaspic.setLastAuthenticationStatus;
 
@@ -154,7 +153,7 @@ public class HttpBridgeServerAuthModule implements ServerAuthModule {
     private HttpAuthenticationMechanism getMechanism(HttpMessageContext ctx) throws AuthException {
         String mechanism = getMechanismName(ctx.getRequest());
         Class<? extends HttpAuthenticationMechanism> mechanismClass = findMechanismClass(mechanism);
-        return CDI.current().select(mechanismClass).get();
+        return CdiUtils.getBeanReference(mechanismClass); // CDI.current() is in context of HttpBridgeServerAuthModule, not the app itself!
     }
 
     private String getMechanismName(HttpServletRequest request) {

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <groupId>org.glassfish.soteria</groupId>
     <artifactId>parent</artifactId>
-    <version>1.1-b01.payara-p6-SNAPSHOT</version>
+    <version>1.1-b01.payara-p6</version>
     <packaging>pom</packaging>
 
     <inceptionYear>2015</inceptionYear>

--- a/test/app-custom-identity-store-handler/pom.xml
+++ b/test/app-custom-identity-store-handler/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.1-b01-SNAPSHOT</version>
+        <version>1.1-b01.payara-p6</version>
     </parent>
 
 	<artifactId>app-custom-identity-store-handler</artifactId>
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.1-b01-SNAPSHOT</version>
+            <version>1.1-b01.payara-p6</version>
         </dependency>
 
         <dependency>

--- a/test/app-custom-rememberme/pom.xml
+++ b/test/app-custom-rememberme/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.1-b01-SNAPSHOT</version>
+        <version>1.1-b01.payara-p6</version>
     </parent>
 	
 	<artifactId>app-custom-rememberme</artifactId>
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.1-b01-SNAPSHOT</version>
+            <version>1.1-b01.payara-p6</version>
         </dependency>
     </dependencies>
     

--- a/test/app-custom-session/pom.xml
+++ b/test/app-custom-session/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.1-b01-SNAPSHOT</version>
+        <version>1.1-b01.payara-p6</version>
     </parent>
 	
 	<artifactId>app-custom-session</artifactId>
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.1-b01-SNAPSHOT</version>
+            <version>1.1-b01.payara-p6</version>
         </dependency>
     </dependencies>
     

--- a/test/app-custom/pom.xml
+++ b/test/app-custom/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.1-b01-SNAPSHOT</version>
+        <version>1.1-b01.payara-p6</version>
     </parent>
 	
 	<artifactId>app-custom</artifactId>
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.1-b01-SNAPSHOT</version>
+            <version>1.1-b01.payara-p6</version>
         </dependency>
     </dependencies>
     

--- a/test/app-db/pom.xml
+++ b/test/app-db/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.1-b01-SNAPSHOT</version>
+        <version>1.1-b01.payara-p6</version>
     </parent>
 	
 	<artifactId>app-db</artifactId>
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.1-b01-SNAPSHOT</version>
+            <version>1.1-b01.payara-p6</version>
         </dependency>
         
          <dependency>

--- a/test/app-jaxrs/pom.xml
+++ b/test/app-jaxrs/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.1-b01-SNAPSHOT</version>
+        <version>1.1-b01.payara-p6</version>
     </parent>
 	
 	<artifactId>app-jaxrs</artifactId>
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.1-b01-SNAPSHOT</version>
+            <version>1.1-b01.payara-p6</version>
         </dependency>
     </dependencies>
     

--- a/test/app-ldap/pom.xml
+++ b/test/app-ldap/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.1-b01-SNAPSHOT</version>
+        <version>1.1-b01.payara-p6</version>
     </parent>
 	
 	<artifactId>app-ldap</artifactId>
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.1-b01-SNAPSHOT</version>
+            <version>1.1-b01.payara-p6</version>
         </dependency>
         
         <dependency>

--- a/test/app-ldap2/pom.xml
+++ b/test/app-ldap2/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.1-b01-SNAPSHOT</version>
+        <version>1.1-b01.payara-p6</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.1-b01-SNAPSHOT</version>
+            <version>1.1-b01.payara-p6</version>
         </dependency>
         
          <dependency>

--- a/test/app-ldap3/pom.xml
+++ b/test/app-ldap3/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.1-b01-SNAPSHOT</version>
+        <version>1.1-b01.payara-p6</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.1-b01-SNAPSHOT</version>
+            <version>1.1-b01.payara-p6</version>
         </dependency>
         
          <dependency>

--- a/test/app-mem-basic/pom.xml
+++ b/test/app-mem-basic/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.1-b01-SNAPSHOT</version>
+        <version>1.1-b01.payara-p6</version>
     </parent>
 	
     <artifactId>app-mem-basic</artifactId>
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.1-b01-SNAPSHOT</version>
+            <version>1.1-b01.payara-p6</version>
         </dependency>
     </dependencies>
 

--- a/test/app-mem-customform/pom.xml
+++ b/test/app-mem-customform/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.1-b01-SNAPSHOT</version>
+        <version>1.1-b01.payara-p6</version>
     </parent>
 	
 	<artifactId>app-mem-customform</artifactId>
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.1-b01-SNAPSHOT</version>
+            <version>1.1-b01.payara-p6</version>
         </dependency>
     </dependencies>
 

--- a/test/app-mem-form/pom.xml
+++ b/test/app-mem-form/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.1-b01-SNAPSHOT</version>
+        <version>1.1-b01.payara-p6</version>
     </parent>
 	
 	<artifactId>app-mem-form</artifactId>
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.1-b01-SNAPSHOT</version>
+            <version>1.1-b01.payara-p6</version>
         </dependency>
     </dependencies>
 

--- a/test/app-mem/pom.xml
+++ b/test/app-mem/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.1-b01-SNAPSHOT</version>
+        <version>1.1-b01.payara-p6</version>
     </parent>
 	
 	<artifactId>app-mem</artifactId>
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.1-b01-SNAPSHOT</version>
+            <version>1.1-b01.payara-p6</version>
         </dependency>
     </dependencies>
     

--- a/test/app-multiple-store-backup/pom.xml
+++ b/test/app-multiple-store-backup/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.1-b01-SNAPSHOT</version>
+        <version>1.1-b01.payara-p6</version>
     </parent>
 	
 	<artifactId>app-multiple-store-backup</artifactId>
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.1-b01-SNAPSHOT</version>
+            <version>1.1-b01.payara-p6</version>
         </dependency>
     </dependencies>
     

--- a/test/app-multiple-store/pom.xml
+++ b/test/app-multiple-store/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.1-b01-SNAPSHOT</version>
+        <version>1.1-b01.payara-p6</version>
     </parent>
 	
 	<artifactId>app-multiple-store</artifactId>
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.1-b01-SNAPSHOT</version>
+            <version>1.1-b01.payara-p6</version>
         </dependency>
     </dependencies>
     

--- a/test/app-securitycontext-auth/pom.xml
+++ b/test/app-securitycontext-auth/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.1-b01-SNAPSHOT</version>
+        <version>1.1-b01.payara-p6</version>
     </parent>
 	
 	<artifactId>app-securitycontext-auth</artifactId>
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.1-b01-SNAPSHOT</version>
+            <version>1.1-b01.payara-p6</version>
         </dependency>
     </dependencies>
     

--- a/test/app-securitycontext-customprincipal/pom.xml
+++ b/test/app-securitycontext-customprincipal/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.1-b01-SNAPSHOT</version>
+        <version>1.1-b01.payara-p6</version>
     </parent>
 	
 	<artifactId>app-securitycontext-customprincipal</artifactId>
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.1-b01-SNAPSHOT</version>
+            <version>1.1-b01.payara-p6</version>
         </dependency>
     </dependencies>
     

--- a/test/app-securitycontext/pom.xml
+++ b/test/app-securitycontext/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.1-b01-SNAPSHOT</version>
+        <version>1.1-b01.payara-p6</version>
     </parent>
 	
 	<artifactId>app-securitycontext</artifactId>
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.1-b01-SNAPSHOT</version>
+            <version>1.1-b01.payara-p6</version>
         </dependency>
     </dependencies>
     

--- a/test/common/pom.xml
+++ b/test/common/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.1-b01-SNAPSHOT</version>
+        <version>1.1-b01.payara-p6</version>
     </parent>
     
     <artifactId>common</artifactId>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -47,12 +47,11 @@
     <parent>
        <groupId>org.glassfish.soteria</groupId>
        <artifactId>parent</artifactId>
-       <version>1.1-b01.payara-p5</version>
+       <version>1.1-b01.payara-p6</version>
     </parent>
 
     <groupId>org.glassfish.soteria.test</groupId>
     <artifactId>parent</artifactId>
-    <version>1.1-b01-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Soteria Integration Tests and Examples</name>
@@ -218,7 +217,7 @@
                 <dependency>
                     <groupId>org.glassfish.soteria</groupId>
                     <artifactId>javax.security.enterprise</artifactId>
-                    <version>1.1-b01-SNAPSHOT</version>
+                    <version>1.1-b01.payara-p6</version>
                 </dependency>
             </dependencies>
         </profile> 


### PR DESCRIPTION
## Description
Search for CDI doesn't work well in EAR packaging.
The current way searches through all modules, which can find the calling class. And because EJB module sees the WAR classes, it may be (and often is) chosen instead of the WAR, causing further CDI search failures.

This change mimics behavior of version 3, which uses tries to find "java:comp/BeanManager" in JNDI, which works more reliably.

I left a comment, so future change doesn't return to CDI.current().