### PR TITLE
Add support for evaluating ExtraParametersExpression in OpenID

### DIFF
--- a/impl/src/main/java/org/glassfish/soteria/mechanisms/openid/controller/AuthenticationController.java
+++ b/impl/src/main/java/org/glassfish/soteria/mechanisms/openid/controller/AuthenticationController.java
@@ -29,6 +29,7 @@ import static jakarta.security.enterprise.authentication.mechanism.http.openid.O
 import static jakarta.security.enterprise.authentication.mechanism.http.openid.OpenIdConstant.SCOPE;
 import static java.util.logging.Level.FINEST;
 import static org.glassfish.soteria.Utils.isEmpty;
+import static org.glassfish.soteria.cdi.AnnotationELPProcessor.evalELExpression;
 import static org.glassfish.soteria.mechanisms.OpenIdAuthenticationMechanism.ORIGINAL_REQUEST_DATA_JSON;
 
 import java.io.IOException;
@@ -122,8 +123,25 @@ public class AuthenticationController {
             authRequest.queryParam(PROMPT, configuration.getPrompt());
         }
 
-        configuration.getExtraParameters().forEach(authRequest::queryParam);
+        if(!isEmpty(configuration.getExtraParametersExpression())){
 
+            String evaluatedExtraParametersExpression = evalELExpression(configuration.getExtraParametersExpression());            
+
+            String[] extraParameters = evaluatedExtraParametersExpression.split(",");
+
+            for (String extraParameter : extraParameters) {
+                String[] keyValue = extraParameter.split("=");
+                if (keyValue.length == 2) {
+                    authRequest.queryParam(keyValue[0].trim(), keyValue[1].trim());
+                } else {
+                    LOGGER.warning("Invalid extra parameter format: " + extraParameter);
+                }
+            }
+
+        }else{
+            configuration.getExtraParameters().forEach(authRequest::queryParam);
+        }
+    
         String authUrl = authRequest.build().toString();
         LOGGER.log(FINEST, "Redirecting for authentication to {0}", authUrl);
         try {

--- a/impl/src/main/java/org/glassfish/soteria/mechanisms/openid/controller/ConfigurationController.java
+++ b/impl/src/main/java/org/glassfish/soteria/mechanisms/openid/controller/ConfigurationController.java
@@ -211,6 +211,8 @@ public class ConfigurationController implements Serializable {
                 .collect(joining(SPACE_SEPARATOR));
         prompt = evalImmediate(definition.promptExpression(), prompt);
 
+        String extraParametersExpression = definition.extraParametersExpression();
+
         Map<String, String> extraParameters = new HashMap<>();
         for (String extraParameter : definition.extraParameters()) {
             String[] parts = extraParameter.split("=");
@@ -268,6 +270,7 @@ public class ConfigurationController implements Serializable {
                 .setScopes(scopes)
                 .setResponseType(responseType)
                 .setResponseMode(responseMode)
+                .setExtraParametersExpression(extraParametersExpression)
                 .setExtraParameters(extraParameters)
                 .setPrompt(prompt)
                 .setDisplay(display)

--- a/impl/src/main/java/org/glassfish/soteria/mechanisms/openid/domain/OpenIdConfiguration.java
+++ b/impl/src/main/java/org/glassfish/soteria/mechanisms/openid/domain/OpenIdConfiguration.java
@@ -40,6 +40,7 @@ public class OpenIdConfiguration {
     private String responseType;
     private String responseMode;
     private Map<String, String> extraParameters;
+    private String extraParametersExpression;
     private String prompt;
     private String display;
     private boolean useNonce;
@@ -132,6 +133,15 @@ public class OpenIdConfiguration {
 
     public OpenIdConfiguration setExtraParameters(Map<String, String> extraParameters) {
         this.extraParameters = extraParameters;
+        return this;
+    }
+
+    public String getExtraParametersExpression() {
+        return extraParametersExpression;
+    }
+
+    public OpenIdConfiguration setExtraParametersExpression(String extraParametersExpression) {
+        this.extraParametersExpression = extraParametersExpression;
         return this;
     }
 
@@ -245,6 +255,7 @@ public class OpenIdConfiguration {
                 + ", responseType=" + responseType
                 + ", responseMode=" + responseMode
                 + ", extraParameters=" + extraParameters
+                + ", extraParametersExpression=" + extraParametersExpression
                 + ", prompt=" + prompt
                 + ", display=" + display
                 + ", useNonce=" + useNonce


### PR DESCRIPTION
This pull request add support for evaluating the extraParametersExpression attribute defined in the [Jakarta Security specification for OpenIDAuthenticationMechanismDefinition](https://jakarta.ee/specifications/webprofile/10/apidocs/jakarta/security/enterprise/authentication/mechanism/http/openidauthenticationmechanismdefinition#extraParametersExpression).

I think the implementation follows the expected behavior described in the Jakarta EE 10 Web Profile documentation and ensures compatibility with existing configurations that do not use this attribute.

Please let me know if any adjustments are needed or if further clarification is required. Thank you for reviewing this contribution!

